### PR TITLE
Update throw-exceptions.md

### DIFF
--- a/knpu/episode4/throw-exceptions.md
+++ b/knpu/episode4/throw-exceptions.md
@@ -32,7 +32,7 @@ file, we forgot to change it to `\Exception`:
 
 That's better. Now refresh again. *This* is a much better error:
 
-> Uncaught `Exception`: Invalid strength passed: "banana"
+> Uncaught `Exception`: Strength must be a number, duh
 
 ## When things go Wrong: Throw an Exception
 


### PR DESCRIPTION
Fixing exception message.

BTW: This line doesn't make sense, since the code block is identical to the block above (or I'm blind...):

> But first, Exception is a core PHP class, and when we added a namespace to this file, we forgot to change it to \Exception: